### PR TITLE
added self.close ()

### DIFF
--- a/resources/lib/addConnection.py
+++ b/resources/lib/addConnection.py
@@ -110,6 +110,9 @@ class GUI(xbmcgui.WindowXMLDialog):
     def onAction(self, action):
         if action in self.action_cancel_dialog:
             self.closeDialog()
+            
+    def closeDialog(self):
+        self.close()
 
     def onFocus(self, controlId):
         msg = ""


### PR DESCRIPTION
Cancel button was not working, or the "hidden button" that should close the dialog box upon successful connection to wi-fi, resulting in a need to restart XBMC. This fixes the issue as suggested by rome on the Kodi forum. Tested on Apple TV 1 running Crystalbuntu 2.0
